### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/HarDatacreationC.cpp
+++ b/src/HarDatacreationC.cpp
@@ -40,7 +40,7 @@ arma::mat HARDataCreationC(arma::vec vRealizedMeasure , arma::vec vPeriods, int 
 arma::mat HARMatCombine(arma::mat mA, arma::mat mB){
   int iRowsA = mA.n_rows;
   int iRowsB = mB.n_rows;
-  arma:: vec vFoo(2); vFoo << iRowsA << iRowsB <<endr;
+  arma:: vec vFoo({ iRowsA, iRowsB });
   arma::mat mC((arma::min(vFoo)), (mA.n_cols+mB.n_cols));
   if(iRowsA > iRowsB){
     mA.shed_rows(0, iRowsA-iRowsB-1);


### PR DESCRIPTION
This one-line change updates RcppArmadillo from the now deprecated `<<` initialization to brace initialization allowed since C++11 and long been the minimal standard with R too. It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at RcppCore/RcppArmadillo#391

The change was also tested with `R CMD check` and produced no issues.